### PR TITLE
fix :: 답변 수에 따라 순서를 건너뛰는 현상 해결

### DIFF
--- a/src/main/java/org/plteco/ploytechcourse/application/grading/service/GradingServiceApplicationImpl.java
+++ b/src/main/java/org/plteco/ploytechcourse/application/grading/service/GradingServiceApplicationImpl.java
@@ -149,7 +149,7 @@ public class GradingServiceApplicationImpl implements GradingServiceApplication 
 
         int count = 1 + (int) gradingForm.getAnswers().stream()
                 .filter(answer -> answer.getGrader().getId().equals(grader.getId()))
-                .count();
+                .count() / gradingForm.getGradingQuestions().size();
 
         GradingPresentationOrder gradingPresentationOrder = gradingForm.getPresentationOrders().stream()
                 .filter(order -> order.getOrderIndex() == count).findFirst().get();


### PR DESCRIPTION
 - [ ] 확인한 결과 답변 수에 따라 순서가 건너뛰어지는 현상을 발견했습니다.
 - [ ] 답변수를 질문 수로 나눠서 정상 반영되도록 고쳤습니다
 